### PR TITLE
routeHandler.handler now matches urls with params

### DIFF
--- a/backend/routeHandler/routeHandler.js
+++ b/backend/routeHandler/routeHandler.js
@@ -4,7 +4,6 @@ function parseURL(event) {
   url.path;
 }
 
-routeMapping["GET"].url;
 const router = {
   get: (url, handler) => {
     routeMapping.GET[url] = handler;
@@ -45,8 +44,25 @@ async function routeHandler(event, context) {
     ) {
       return routeMapping[event.httpMethod][event.path](event, context);
     } else if (routeMapping[event.httpMethod]) {
-      for (const key in Object.keys(routeMapping[event.httpMethod])) {
-        // if It matches the :id regex
+      for (const url of Object.keys(routeMapping[event.httpMethod])) {
+        // get all matches of pathParameters in the url designated by a colon then a word like character.
+        const matches = url.match(/:\w+[^\\]/g);
+        let replacedPath = url;
+        // replace all 
+        for (const match of matches) {
+          const colonlessMatch = match.substring(1);
+          replacedPath = replacedPath.replace(
+            match,
+            event.pathParameters[colonlessMatch]
+          );
+        }
+        if (event.path === replacedPath) {
+          return routeMapping[event.httpMethod][url](event, context);
+        } else {
+          // Raise 404 Error for unknown path
+          statusCode = "404";
+          body = "Path not found";
+        }
       }
     } else {
       // Raise error for unsupported HTTP verb


### PR DESCRIPTION
Basically we iterate over all the url paths that were stored by calling something like router.get(...) then we take all pathParameters in the given url and replace their parameter parts with the pathParameters given by AWS lambda's event.

I was unable to test this code, but I thought I might as well send it and let you take it from there. Feel free to discuss or ask me any questions if you're interested in knowing more about these changes or if you need any assistance @jordonpeterson. 